### PR TITLE
Make the twirl_compiler attribute public

### DIFF
--- a/compiler-cli/BUILD.bazel
+++ b/compiler-cli/BUILD.bazel
@@ -1,0 +1,6 @@
+java_binary(
+  name = "compiler-cli",
+  runtime_deps = ["@twirl//:com_lucidchart_twirl_compiler_cli"],
+  main_class = "rulestwirl.twirl.CommandLineTwirlTemplateCompiler",
+  visibility = ["//visibility:public"]
+)

--- a/docs/stardoc/twirl.md
+++ b/docs/stardoc/twirl.md
@@ -5,7 +5,7 @@
 ## twirl_templates
 
 <pre>
-twirl_templates(<a href="#twirl_templates-name">name</a>, <a href="#twirl_templates-additional_imports">additional_imports</a>, <a href="#twirl_templates-include_play_imports">include_play_imports</a>, <a href="#twirl_templates-source_directory">source_directory</a>, <a href="#twirl_templates-srcs">srcs</a>, <a href="#twirl_templates-template_formats">template_formats</a>)
+twirl_templates(<a href="#twirl_templates-name">name</a>, <a href="#twirl_templates-additional_imports">additional_imports</a>, <a href="#twirl_templates-include_play_imports">include_play_imports</a>, <a href="#twirl_templates-source_directory">source_directory</a>, <a href="#twirl_templates-srcs">srcs</a>, <a href="#twirl_templates-template_formats">template_formats</a>, <a href="#twirl_templates-twirl_compiler">twirl_compiler</a>)
 </pre>
 
 Compiles Twirl templates to Scala sources files.
@@ -78,6 +78,12 @@ The default formats are
 "js" -> "play.twirl.api.JavaScriptFormat"
 ```
         </p>
+      </td>
+    </tr>
+    <tr id="twirl_templates-twirl_compiler">
+      <td><code>twirl_compiler</code></td>
+      <td>
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
       </td>
     </tr>
   </tbody>

--- a/twirl/BUILD.bazel
+++ b/twirl/BUILD.bazel
@@ -38,10 +38,3 @@ bzl_library(
     name = "jdk_toolchain_utils",
     srcs = ["@bazel_tools//tools/jdk:toolchain_utils.bzl"],
 )
-
-java_binary(
-  name = "compiler-cli",
-  runtime_deps = ["@twirl//:com_lucidchart_twirl_compiler_cli"],
-  main_class = "rulestwirl.twirl.CommandLineTwirlTemplateCompiler",
-  visibility = ["//visibility:public"]
-)

--- a/twirl/twirl.bzl
+++ b/twirl/twirl.bzl
@@ -51,7 +51,7 @@ def _impl(ctx):
       mnemonic = "TwirlCompile",
       execution_requirements = {"supports-workers": "1"},
       progress_message = "Compiling twirl template",
-      executable = ctx.executable._twirl_compiler,
+      executable = ctx.executable.twirl_compiler,
     )
 
     outputs.append(output)
@@ -94,11 +94,11 @@ The default formats are
 ```
 """
     ),
-    "_twirl_compiler": attr.label(
+    "twirl_compiler": attr.label(
       executable = True,
       cfg = "host",
       allow_files = True,
-      default = Label("//twirl:compiler-cli"),
+      default = Label("//compiler-cli"),
     )
   },
 )


### PR DESCRIPTION
Also moved the default compiler to its own package to stop leaking dependencies