### PR TITLE
Allow environment variables to be passed to the compiler

### DIFF
--- a/compiler-cli/BUILD.bazel
+++ b/compiler-cli/BUILD.bazel
@@ -1,28 +1,6 @@
 java_binary(
-    name = "standard-compiler-cli",
-    main_class = "rulestwirl.twirl.CommandLineTwirlTemplateCompiler",
-    visibility = ["//visibility:public"],
-    runtime_deps = ["@twirl//:com_lucidchart_twirl_compiler_cli"],
-)
-
-java_binary(
-    name = "utf8-compiler-cli",
-    jvm_flags = ["-Dfile.encoding=UTF-8"],
-    main_class = "rulestwirl.twirl.CommandLineTwirlTemplateCompiler",
-    visibility = ["//visibility:public"],
-    runtime_deps = ["@twirl//:com_lucidchart_twirl_compiler_cli"],
-)
-
-config_setting(
-    name = "utf8",
-    values = {"define": "twirl.compiler.encoding=utf8"},
-)
-
-alias(
     name = "compiler-cli",
-    actual = select({
-        ":utf8": "utf8-compiler-cli",
-        "//conditions:default": "standard-compiler-cli",
-    }),
+    main_class = "rulestwirl.twirl.CommandLineTwirlTemplateCompiler",
     visibility = ["//visibility:public"],
+    runtime_deps = ["@twirl//:com_lucidchart_twirl_compiler_cli"],
 )

--- a/compiler-cli/BUILD.bazel
+++ b/compiler-cli/BUILD.bazel
@@ -1,6 +1,28 @@
 java_binary(
-  name = "compiler-cli",
-  runtime_deps = ["@twirl//:com_lucidchart_twirl_compiler_cli"],
-  main_class = "rulestwirl.twirl.CommandLineTwirlTemplateCompiler",
-  visibility = ["//visibility:public"]
+    name = "standard-compiler-cli",
+    main_class = "rulestwirl.twirl.CommandLineTwirlTemplateCompiler",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["@twirl//:com_lucidchart_twirl_compiler_cli"],
+)
+
+java_binary(
+    name = "utf8-compiler-cli",
+    jvm_flags = ["-Dfile.encoding=UTF-8"],
+    main_class = "rulestwirl.twirl.CommandLineTwirlTemplateCompiler",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["@twirl//:com_lucidchart_twirl_compiler_cli"],
+)
+
+config_setting(
+    name = "utf8",
+    values = {"define": "twirl.compiler.encoding=utf8"},
+)
+
+alias(
+    name = "compiler-cli",
+    actual = select({
+        ":utf8": "utf8-compiler-cli",
+        "//conditions:default": "standard-compiler-cli",
+    }),
+    visibility = ["//visibility:public"],
 )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -2,54 +2,77 @@ load("@rules_scala_annex//rules:scala.bzl", "scala_test")
 load("//twirl:twirl.bzl", "twirl_templates")
 
 twirl_templates(
-  name = "twirl-test-templates-basic",
-  visibility = ["//visibility:public"],
-  source_directory = "twirl-templates",
-  srcs = [
-    "twirl-templates/twirl/com/foo/views/hello.scala.html",
-    "twirl-templates/twirl/com/foo/views/hello.scala.txt",
-    "twirl-templates/twirl/com/foo/views/hello.scala.xml",
-    "twirl-templates/twirl/com/foo/views/hello.scala.js",
-  ],
+    name = "twirl-test-templates-basic",
+    srcs = [
+        "twirl-templates/twirl/com/foo/views/hello.scala.html",
+        "twirl-templates/twirl/com/foo/views/hello.scala.js",
+        "twirl-templates/twirl/com/foo/views/hello.scala.txt",
+        "twirl-templates/twirl/com/foo/views/hello.scala.xml",
+    ],
+    source_directory = "twirl-templates",
+    visibility = ["//visibility:public"],
 )
 
 twirl_templates(
-  name = "twirl-test-templates-additional-imports",
-  visibility = ["//visibility:public"],
-  source_directory = "twirl-templates",
-  srcs = [
-    "twirl-templates/twirl/com/foo/views/addImports.scala.txt",
-  ],
-  additional_imports = ["rulestwirl.test.Person"],
+    name = "twirl-test-templates-additional-imports",
+    srcs = [
+        "twirl-templates/twirl/com/foo/views/addImports.scala.txt",
+    ],
+    additional_imports = ["rulestwirl.test.Person"],
+    source_directory = "twirl-templates",
+    visibility = ["//visibility:public"],
 )
 
 twirl_templates(
-  name = "twirl-test-templates-custom-formatter",
-  visibility = ["//visibility:public"],
-  source_directory = "twirl-templates",
-  srcs = [
-    "twirl-templates/twirl/com/foo/views/customFormatter.scala.txt",
-  ],
-  additional_imports = ["rulestwirl.test.Person"],
-  template_formats = {
-    "txt": "rulestwirl.test.StrangeTxtFormat"
-  },
+    name = "twirl-test-templates-custom-formatter",
+    srcs = [
+        "twirl-templates/twirl/com/foo/views/customFormatter.scala.txt",
+    ],
+    additional_imports = ["rulestwirl.test.Person"],
+    source_directory = "twirl-templates",
+    template_formats = {
+        "txt": "rulestwirl.test.StrangeTxtFormat",
+    },
+    visibility = ["//visibility:public"],
 )
 
 scala_test(
-  name = "twirl-compiler-test",
-  srcs = [
-    "TwirlCompilerTest.scala",
-    "Person.scala",
-    "StrangeTxtFormatter.scala",
-    ":twirl-test-templates-basic",
-    ":twirl-test-templates-additional-imports",
-    ":twirl-test-templates-custom-formatter",
-  ],
-  deps = [
-    "@twirl_test//:com_typesafe_play_twirl_api_2_12",
-    "@twirl_test//:org_specs2_specs2_common_2_12",
-    "@twirl_test//:org_specs2_specs2_core_2_12",
-    "@twirl_test//:org_specs2_specs2_matcher_2_12",
-  ],
+    name = "twirl-compiler-test",
+    srcs = [
+        "Person.scala",
+        "StrangeTxtFormatter.scala",
+        "TwirlCompilerTest.scala",
+        ":twirl-test-templates-additional-imports",
+        ":twirl-test-templates-basic",
+        ":twirl-test-templates-custom-formatter",
+    ],
+    deps = [
+        "@twirl_test//:com_typesafe_play_twirl_api_2_12",
+        "@twirl_test//:org_specs2_specs2_common_2_12",
+        "@twirl_test//:org_specs2_specs2_core_2_12",
+        "@twirl_test//:org_specs2_specs2_matcher_2_12",
+    ],
+)
+
+twirl_templates(
+    name = "twirl-test-templates-utf8",
+    srcs = [
+        "twirl-templates/twirl/com/foo/utf8/hello.scala.html",
+        "twirl-templates/twirl/com/foo/utf8/hello.scala.txt",
+    ],
+    source_directory = "twirl-templates",
+)
+
+scala_test(
+    name = "twirl-compiler-utf8-test",
+    srcs = [
+        "UTF8TwirlCompilerTest.scala",
+        ":twirl-test-templates-utf8",
+    ],
+    deps = [
+        "@twirl_test//:com_typesafe_play_twirl_api_2_12",
+        "@twirl_test//:org_specs2_specs2_common_2_12",
+        "@twirl_test//:org_specs2_specs2_core_2_12",
+        "@twirl_test//:org_specs2_specs2_matcher_2_12",
+    ],
 )

--- a/test/UTF8TwirlCompilerTest.scala
+++ b/test/UTF8TwirlCompilerTest.scala
@@ -1,0 +1,24 @@
+package rulestwirl.test
+
+import org.specs2.mutable.Specification
+
+class UTF8TwirlCompilerTest extends Specification {
+
+  "Twirl Template Compiler when run through Bazel with UTF8 encoding set" should {
+    "Compile html Twirl Templates" in {
+      import twirl.com.foo.utf8.html.hello
+      val name = "Fred"
+      val age = 37
+      val template = hello.render(name, age)
+      template.body mustEqual s"<html>’$name’, age: $age</html>"
+    }
+
+    "Compile txt Twirl Templates" in {
+      import twirl.com.foo.utf8.txt.hello
+      val name = "Oliver"
+      val age = 28
+      val template = hello.render(name, age)
+      template.body mustEqual s"$name, age – $age"
+    }
+  }
+}

--- a/test/twirl-templates/twirl/com/foo/utf8/hello.scala.html
+++ b/test/twirl-templates/twirl/com/foo/utf8/hello.scala.html
@@ -1,0 +1,1 @@
+@(name: String, age: Int = 42)<html>’@name’, age: @age</html>

--- a/test/twirl-templates/twirl/com/foo/utf8/hello.scala.txt
+++ b/test/twirl-templates/twirl/com/foo/utf8/hello.scala.txt
@@ -1,0 +1,1 @@
+@(name: String, age: Int = 42)@name, age – @age

--- a/test/twirl_compiler_bazel_e2e_test.sh
+++ b/test/twirl_compiler_bazel_e2e_test.sh
@@ -5,4 +5,4 @@ set -e
 bazel test //test:twirl-compiler-test
 
 # Added an extra option of logback.configurationFile just to show that the encoding will be used regardless of other JVM options used.
-bazel test --action_env JAVA_TOOL_OPTIONS="-Dlogback.configurationFile=/path/to/config.xml -Dfile.encoding=UTF-8" --define twirl.compiler.encoding=utf8 //test:twirl-compiler-utf8-test
+bazel test --action_env JAVA_TOOL_OPTIONS="-Dlogback.configurationFile=/path/to/config.xml -Dfile.encoding=UTF-8" //test:twirl-compiler-utf8-test

--- a/test/twirl_compiler_bazel_e2e_test.sh
+++ b/test/twirl_compiler_bazel_e2e_test.sh
@@ -3,3 +3,6 @@
 set -e
 
 bazel test //test:twirl-compiler-test
+
+# Added an extra option of logback.configurationFile just to show that the encoding will be used regardless of other JVM options used.
+bazel test --action_env JAVA_TOOL_OPTIONS="-Dlogback.configurationFile=/path/to/config.xml -Dfile.encoding=UTF-8" --define twirl.compiler.encoding=utf8 //test:twirl-compiler-utf8-test

--- a/twirl/twirl.bzl
+++ b/twirl/twirl.bzl
@@ -50,6 +50,7 @@ def _impl(ctx):
       arguments = [args],
       mnemonic = "TwirlCompile",
       execution_requirements = {"supports-workers": "1"},
+      use_default_shell_env = True,
       progress_message = "Compiling twirl template",
       executable = ctx.executable.twirl_compiler,
     )


### PR DESCRIPTION
Tackling this issue: https://github.com/lucidsoftware/rules_twirl/issues/27

I have set the `use_default_shell_env` property to `True` to pass on any environment variables the user sets. I would like to suggest this as a better approach rather than setting the specific UTF8 values and trying to use that since it allows for other encodings and JVM config values clients may want.

I am happy to revisit a different approach if this is not desired, this feels less brittle to me though.