### PR TITLE
bypass securitymanager deprecation in jdk 21

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,17 +79,19 @@ load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 
 sass_repositories()
 
-
 rules_pkg_version = "0.9.1"
+
 http_archive(
-  name = "rules_pkg",
-  sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
-  urls = [
-    "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/{0}/rules_pkg-{0}.tar.gz".format(rules_pkg_version),
-    "https://github.com/bazelbuild/rules_pkg/releases/download/{0}/rules_pkg-{0}.tar.gz".format(rules_pkg_version),
-  ],
+    name = "rules_pkg",
+    sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/{0}/rules_pkg-{0}.tar.gz".format(rules_pkg_version),
+        "https://github.com/bazelbuild/rules_pkg/releases/download/{0}/rules_pkg-{0}.tar.gz".format(rules_pkg_version),
+    ],
 )
+
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
 rules_pkg_dependencies()
 
 # Skydoc
@@ -176,4 +178,19 @@ load("@annex//:defs.bzl", annex_pinned_maven_install = "pinned_maven_install")
 
 annex_pinned_maven_install()
 
-scala_register_toolchains()
+http_archive(
+    name = "io_bazel_rules_scala",
+    sha256 = "7adaec1cc787ca1519550e71dbd0cb9c149ee1b06f04ba91dda07c12483aae57",
+    strip_prefix = "rules_scala-6.3.0",
+    url = "https://github.com/bazelbuild/rules_scala/releases/download/v6.3.0/rules_scala-v6.3.0.tar.gz",
+)
+
+load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+
+scala_config(scala_version = "2.13.12")
+
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+
+scala_repositories()
+
+register_toolchains("//toolchain/scala")

--- a/toolchain/scala/BUILD.bazel
+++ b/toolchain/scala/BUILD.bazel
@@ -1,0 +1,62 @@
+load("@io_bazel_rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
+load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
+
+scala_toolchain(
+    name = "impl",
+    dependency_mode = "plus-one",
+    dependency_tracking_method = "ast",
+    scalac_jvm_flags = ["-Djava.security.manager=allow"],
+    # https://nathankleyn.com/2019/05/13/recommended-scalac-flags-for-2-13/
+    scalacopts = [
+        "-Xsource:3",  # Scala 3 sources
+        "-deprecation",  # Emit warning and location for usages of deprecated APIs.
+        "-explaintypes",  # Explain type errors in more detail.
+        "-feature",  # Emit warning and location for usages of features that should be imported explicitly.
+        "-language:existentials",  # Existential types (besides wildcard types) can be written and inferred
+        "-language:experimental.macros",  # Allow macro definition (besides implementation and application)
+        "-language:higherKinds",  # Allow higher-kinded types
+        "-language:implicitConversions",  # Allow definition of implicit functions called views
+        "-unchecked",  # Enable additional warnings where generated code depends on assumptions.
+        "-Xcheckinit",  # Wrap field accessors to throw an exception on uninitialized access.
+        "-Xfatal-warnings",  # Fail the compilation if there are any warnings.
+        "-Xlint:adapted-args",  # Warn if an argument list is modified to match the receiver.
+        "-Xlint:constant",  # Evaluation of a constant arithmetic expression results in an error.
+        "-Xlint:delayedinit-select",  # Selecting member of DelayedInit.
+        "-Xlint:doc-detached",  # A Scaladoc comment appears to be detached from its element.
+        "-Xlint:inaccessible",  # Warn about inaccessible types in method signatures.
+        "-Xlint:infer-any",  # Warn when a type argument is inferred to be `Any`.
+        "-Xlint:missing-interpolator",  # A string literal appears to be missing an interpolator id.
+        #"-Xlint:nullary-override",  # Warn when non-nullary `def f()' overrides nullary `def f'.
+        "-Xlint:nullary-unit",  # Warn when nullary methods return Unit.
+        "-Xlint:option-implicit",  # Option.apply used implicit view.
+        "-Xlint:package-object-classes",  # Class or object defined in package object.
+        "-Xlint:poly-implicit-overload",  # Parameterized overloaded implicit methods are not visible as view bounds.
+        "-Xlint:private-shadow",  # A private field (or class parameter) shadows a superclass field.
+        "-Xlint:stars-align",  # Pattern sequence wildcard must align with sequence component.
+        "-Xlint:type-parameter-shadow",  # A local type parameter shadows a type already in scope.
+        #"-Ywarn-dead-code",  # Warn when dead code is identified.
+        "-Ywarn-extra-implicit",  # Warn when more than one implicit parameter section is defined.
+        "-Ywarn-numeric-widen",  # Warn when numerics are widened.
+        #"-Ywarn-unused:implicits",  # Warn if an implicit parameter is unused.
+        #"-Ywarn-unused:imports",  # Warn if an import selector is not referenced.
+        "-Ywarn-unused:locals",  # Warn if a local definition is unused.
+        #"-Ywarn-unused:params",  # Warn if a value parameter is unused.
+        "-Ywarn-unused:patvars",  # Warn if a variable bound in a pattern is unused.
+        #"-Ywarn-unused:privates",  # Warn if a private member is unused.
+        "-Ywarn-value-discard",  # Warn when non-Unit expression results are unused.
+        "-Ybackend-parallelism",
+        "8",  # Enable paralellisation — change to desired number!
+        "-Ycache-plugin-class-loader:last-modified",  # Enables caching of classloaders for compiler plugins
+        "-Ycache-macro-class-loader:last-modified",  # and macro definitions. This can lead to performance improvements.
+    ],
+    #strict_deps_mode = "error",
+    #unused_dependency_checker_mode = "error",
+    visibility = ["//visibility:private"],
+)
+
+toolchain(
+    name = "scala",
+    toolchain = ":impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
If you want to go forward with this, I'll clean up the PR. Right now compilation fails on JDK 21 because of the SecurityManager deprecation.